### PR TITLE
closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,14 @@ console.log(robots)
 }
 ```
 
-プロパティ名と値を指定することで、条件に一致するRobotを検索することができました。
-条件指定は ``$filter`` 以外にもいくつかありますが、その仕様は [API リクエストの構築](https://docs.uipath.com/orchestrator/lang-ja/reference#building-api-requests) ココに詳しく書いてあります。
+``「`MachineName eq '${machinename}' and Username eq '${userName}'`」``などとRobotの
+プロパティ名とその値を指定することで、条件に一致するRobotを検索することができました。
+条件指定は ``$filter`` 以外にも ``$top`` や ``$select`` などいくつかありますが、その仕様は [API リクエストの構築](https://docs.uipath.com/orchestrator/lang-ja/reference#building-api-requests) のサイトに詳しく書いてあります。
 
 
 ## 使用するための前準備
 
-さて、本来ブラリを使用するには、接続するUiPath Orchestratorの接続上などの環境設定が必要です。
+さて、本ライブラリを使用するには、接続するUiPath Orchestratorの情報など環境設定が必要です。
 
 
 UiPath Orchestrator がEnterprise版の場合:
@@ -156,7 +157,7 @@ $ tree
 $
 ```
 
-それぞれのファイルは以下のようにします。
+それぞれのファイルはたとえば以下のようにします。
 
 ```
 $ cat src/index.ts 

--- a/__tests__/OrchestratorApi.spec.ts
+++ b/__tests__/OrchestratorApi.spec.ts
@@ -9,14 +9,14 @@ import config from 'config'
 //   await api.robot.update(robot)
 // }
 
-describe('OrchestratorApi のテスト', () => {
+describe('OrchestratorApi', () => {
   const api = new OrchestratorApi(config)
 
   beforeEach(async () => {
     await api.authenticate()
   })
 
-  describe('OrchestratorApi のテスト', () => {
+  describe('license/Robot/User/Machine/Process/Schedules... のテスト', () => {
     it('license のテスト', async () => {
       // ライセンスを取得する
       const license: any = await api.license.find()
@@ -43,12 +43,12 @@ describe('OrchestratorApi のテスト', () => {
       const machinename = 'PBPC0124'
       const username = 'pb\\pbkino'
       const instances: any[] = await api.robot.findAll({
-        '$filter': `MachineName eq '${machinename}' and Username eq '${username}'`
+        $filter: `MachineName eq '${machinename}' and Username eq '${username}'`,
       })
       expect(instances.length).toBeGreaterThanOrEqual(1)
 
       for (const instance of instances) {
-        console.log(instance)
+        // console.log(instance)
         const robotId: number = instance.Id
         const robot = await api.robot.find(robotId)
         // console.log('RobotId:', robot.Id)
@@ -139,29 +139,6 @@ describe('OrchestratorApi のテスト', () => {
       }
     })
 
-    // it('Queue のテスト', async () => {
-    //   const instances = await api.queue.findAll()
-    //   expect(instances.length).toBeGreaterThanOrEqual(0)
-
-    //   for (const instance of instances) {
-    //     // console.log(instance)
-    //     expect(instance.Id).not.toBeUndefined()
-    //   }
-    //   const queueItemId = instances[0].Id
-    //   const result = await api.queue.find(queueItemId)
-    //   console.log(result)
-    //   expect(result.Id).toBe(queueItemId)
-    // })
-
-    it('汎用メソッド のテスト', async () => {
-      const instances = await api.getArray('/odata/Folders')
-      expect(instances.length).toBeGreaterThanOrEqual(0)
-
-      for (const instance of instances) {
-        // console.log(instance)
-        expect(instance.DisplayName).not.toBeUndefined()
-      }
-    })
   })
 
   describe('Enterprise判別テスト。と認証エラー系', () => {
@@ -215,6 +192,52 @@ describe('OrchestratorApi のテスト', () => {
         expect(error.error).toBe('access_denied')
         expect(error.error_description).toBe('Unauthorized')
       }
+    })
+  })
+
+  describe('Robot判別テスト1。', () => {
+    const api2 = new OrchestratorApi({
+      robotInfo: {
+        machineKey: 'xx',
+        machineName: 'bbbb',
+        userName: 'xxx',
+      },
+      userinfo: {
+        tenancyName: 'default',
+        usernameOrEmailAddress: 'aaa',
+        password: 'bbb',
+      },
+      serverinfo: {
+        servername: 'https://platform.uipath.com/', // ホントはEnterprise サーバでやるべきだけど気にしない
+      },
+    })
+
+    it('Robot判別テスト。', async () => {
+      expect(api2.isEnterprise).toBe(true)
+      expect(api2.isCommunity).toBe(false)
+      expect(api2.isRobot).toBe(true)
+    })
+  })
+
+  describe('Robot判別テスト2.', () => {
+    const api2 = new OrchestratorApi({
+      robotInfo: {
+        machineKey: 'xx',
+        machineName: 'bbbb',
+        userName: 'xxx',
+      },
+      serverinfo: {
+        servername: 'https://platform.uipath.com/kinooqmollho/kinoorgDefault',
+        refresh_token: 'xxx', // User Key
+        tenant_logical_name: 'kinoorgxx',
+        client_id: 'xxxx',
+      },
+    })
+
+    it('Robot判別テスト2', async () => {
+      expect(api2.isCommunity).toBe(true)
+      expect(api2.isEnterprise).toBe(false)
+      expect(api2.isRobot).toBe(true)
     })
   })
 })

--- a/__tests__/OrchestratorApi_general.spec.ts
+++ b/__tests__/OrchestratorApi_general.spec.ts
@@ -1,0 +1,25 @@
+import OrchestratorApi from '../src/index'
+
+import config from 'config'
+
+
+
+describe('OrchestratorApi_general', () => {
+  const api = new OrchestratorApi(config)
+
+  beforeEach(async () => {
+    await api.authenticate()
+  })
+
+  describe('OrchestratorApi のテスト', () => {
+    it('汎用メソッド のテスト', async () => {
+      const instances = await api.getArray('/odata/Folders')
+      expect(instances.length).toBeGreaterThanOrEqual(0)
+
+      for (const instance of instances) {
+        // console.log(instance)
+        expect(instance.DisplayName).not.toBeUndefined()
+      }
+    })
+  })
+})

--- a/__tests__/OrchestratorApi_queue.spec.ts
+++ b/__tests__/OrchestratorApi_queue.spec.ts
@@ -1,0 +1,171 @@
+import OrchestratorApi from '../src/index'
+
+import config from 'config'
+
+describe('OrchestratorApi_queue', () => {
+
+  const api = new OrchestratorApi(config)
+
+  beforeEach(async () => {
+    await api.authenticate()
+  })
+
+  describe('OrchestratorApi のテスト', () => {
+
+    const testQueueDef = {
+      Name: 'testQueue' + Math.floor(Math.random() * 1000),
+      Description: 'Queue for UnitTest',
+      AcceptAutomaticallyRetry: true, // 自動リトライ
+      MaxNumberOfRetries: 3, // 最大リトライ数
+      EnforceUniqueReference: true, // 一意の参照(一意のRefをつけるかどうか)
+    }
+
+    beforeEach(async () => {
+      const result = await api.queueDefinition.create(testQueueDef)
+    })
+
+    describe('Queueにデータを投入して、期待値と比較するテスト。', () => {
+      // 最終的にQueueから取り出されるデータと比較するためのテストデータ。
+      const expected = {
+        MessageId: '<7A6877E2452943F59DEE8AD81FB403A9@12345>',
+        MailDateStr: 'Sat, 7 Dec 2019 02:00:05 +0900',
+        Subject: 'テストメール',
+        MailDate: new Date('2019-12-07T02:00:05+09:00'),
+        Body: 'テストメール。添付の通りです。\r\n',
+        attachmentFileName: 'report_20191206.html',
+      }
+
+      // Queueから取り出されるデータには、型情報がないので比較できないから、それらプロパティは待避。
+      const typeInfo = {
+        'MessageId@odata.type': '#String',
+        'MailDateStr@odata.type': '#String',
+        'Subject@odata.type': '#String',
+        'Body@odata.type': '#String',
+        'attachmentFileName@odata.type': '#String',
+      }
+      // それらを合体
+      const SpecificContentWithType = Object.assign({}, expected, typeInfo)
+
+      // 実際に投入するデータ型。
+      const newQueue = {
+        itemData: {
+          Priority: 'Normal',
+          Name: testQueueDef.Name,
+          SpecificContent: SpecificContentWithType,
+          Reference: expected.MessageId,
+        },
+      }
+
+      it('Queue登録テスト', async () => {
+        let Id: number = 0
+        try {
+          // Queueへデータ投入
+          const result = await api.queueItem.create(newQueue)
+          Id = result.Id
+
+          // console.log(expected)
+          // console.log(result)
+          // console.log(result.SpecificContent)
+          // console.log(result.SpecificContent.MailDate)
+
+          // キー 一致確認
+          const actualReference = result.Reference
+          expect(actualReference).toBe(newQueue.itemData.Reference)
+
+          expect(result.SpecificContent).toEqual({
+            MessageId: expected.MessageId,
+            MailDateStr: expected.MailDateStr,
+            Subject: expected.Subject,
+            MailDate: expect.anything(), // なんでもイイ。下でチェック
+            Body: expected.Body,
+            attachmentFileName: expected.attachmentFileName,
+          })
+
+          // date で投げたデータは文字列で返ってくるので、再度オブジェクトにして比較。
+          expect(typeof result.SpecificContent.MailDate).toBe('string')
+          // expect(result.SpecificContent.MailDate).toBeInstanceOf(String) // なんかうまくいかない
+          expect(new Date(result.SpecificContent.MailDate)).toMatchObject(expected.MailDate)
+
+          // 検索して、見つかること。
+          const findResult = await api.queueItem.find(Id)
+          expect(findResult.Id).toBe(Id)
+        } catch (error) {
+          console.log(Id)
+          fail(error)
+        } finally {
+          // 最後に削除。
+          await api.queueItem.delete(Id)
+        }
+      })
+
+      afterEach(async () => { })
+    })
+
+    afterEach(async () => {
+      const queueDefs: any[] = await api.queueDefinition.findByName(testQueueDef.Name)
+      // console.table(queueDefs)
+      for (const queueDef of queueDefs) {
+        await api.queueDefinition.delete(queueDef.Id)
+      }
+    })
+
+  })
+
+
+  describe('OrchestratorApi のテスト1', () => {
+    describe('QueueDefを作成する。期待値と比較するテスト。', () => {
+
+      const expected = {
+        Name: 'testQueue' + Math.floor(Math.random() * 1000),
+        Description: 'Queue for UnitTest',
+        AcceptAutomaticallyRetry: true, // 自動リトライ
+        MaxNumberOfRetries: 3, // 最大リトライ数
+        EnforceUniqueReference: true, // 一意の参照(一意のRefをつけるかどうか)
+      }
+
+      it('Queue登録テスト', async () => {
+        let Id: number = 0
+        try {
+          // Queueへデータ投入
+          const result = await api.queueDefinition.create(expected)
+          Id = result.Id
+          expect(result).toEqual({
+            '@odata.context': expect.anything(),
+            'AcceptAutomaticallyRetry': expected.AcceptAutomaticallyRetry,
+            'AnalyticsDataJsonSchema': null,
+            'CreationTime': expect.anything(),
+            'Description': expected.Description,
+            'EnforceUniqueReference': expected.EnforceUniqueReference,
+            'Id': expect.anything(),
+            'MaxNumberOfRetries': expected.MaxNumberOfRetries,
+            'Name': expected.Name,
+            'OutputDataJsonSchema': null,
+            'ProcessScheduleId': null,
+            'ReleaseId': null,
+            'RiskSlaInMinutes': expect.anything(),
+            'SlaInMinutes': expect.anything(),
+            'SpecificDataJsonSchema': null
+          })
+
+          // // date で投げたデータは文字列で返ってくるので、再度オブジェクトにして比較。
+          // expect(typeof result.SpecificContent.MailDate).toBe('string')
+          // // expect(result.SpecificContent.MailDate).toBeInstanceOf(String) // なんかうまくいかない
+          // expect(new Date(result.SpecificContent.MailDate)).toMatchObject(expected.MailDate)
+
+          // 検索して、見つかること。
+          const findResult = await api.queueDefinition.find(Id)
+          expect(findResult.Id).toBe(Id)
+        } catch (error) {
+          console.log(Id)
+          fail(error)
+        } finally {
+          // 最後に削除。
+          await api.queueDefinition.delete(Id)
+        }
+      })
+
+      afterEach(async () => { })
+    })
+
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath-orchestrator-api-node",
-  "version": "0.2.5",
+  "version": "0.3.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath-orchestrator-api-node",
-  "version": "0.2.5",
+  "version": "0.3.0-SNAPSHOT",
   "description": "UiPath Orchestrator API wrapper for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,10 @@ const createArrayPromise = (options: any): Promise<Array<any>> => {
         reject(err)
         return
       }
+      if (response.statusCode >= 400) {
+        logger.main.error(body)
+        reject(body)
+      }
       logger.main.info(body)
       const obj = JSON.parse(body)
       resolve(obj.value) // valueプロパティが配列である想定。
@@ -95,6 +99,10 @@ const createStrPromise = (options: any): Promise<Array<any>> => {
       }
       logger.main.info(options.method)
       logger.main.info(body)
+      if (response.statusCode >= 400) {
+        logger.main.error(body)
+        reject(body)
+      }
       if (body === null || body === '') {
         resolve()
         return
@@ -126,6 +134,10 @@ const createJSONPromise = (options: any): Promise<Array<any>> => {
       }
       logger.main.info(`method: ${options.method}, statuCode: ${response.statusCode}`)
       logger.main.info(body)
+      if (response.statusCode >= 400) {
+        logger.main.error(body)
+        reject(body)
+      }
 
       // PUTのばあい、StatusCodeが200で、Bodyが空のためundefinedになったが正常終了させる。
       if (response.statusCode === 200 && !body) {
@@ -159,10 +171,19 @@ const createOption = (config_: any, accessToken: string, apiPath: string): any =
 
 const headers = (config_: any, accessToken: string): any => {
   const tenant_logical_name = config_.serverinfo.tenant_logical_name
-  const ret = {
-    Authorization: 'Bearer ' + accessToken,
-    'content-type': 'application/json',
-    // 'X-UIPATH-OrganizationUnitId': 1
+  let ret = {}
+  if (config_.robotInfo) {
+    ret = {
+      Authorization: 'UiRobot ' + accessToken,
+      'content-type': 'application/json',
+      // 'X-UIPATH-OrganizationUnitId': 1
+    }
+  } else {
+    ret = {
+      Authorization: 'Bearer ' + accessToken,
+      'content-type': 'application/json',
+      // 'X-UIPATH-OrganizationUnitId': 1
+    }
   }
   if (tenant_logical_name) {
     return Object.assign(ret, {


### PR DESCRIPTION
index.ts

- Robotの認証モードで動く機能を追加。Queueなどを取得、ステータス変更する際はこちらを利用する想定
- QueueDefinitionのCRUDを追加、
- QueueItemのCRUDを追加(もともとqueueって名前だったけどqueueItemに変更しました)
- Transactionを使ったQueueItemの取得変更(Transactionを開始したり、完了させたり) は実装開始(未実装)

utils.ts

- Statusコード400以上はエラーを返す処理を追加
- HttpHeaderを生成する処理でAuthorization: Bearer を生成する箇所で、Authorization: UiRobot を生成する考慮を追加。

テスト整理中。