### PR TITLE
Feature/add transaction

### DIFF
--- a/__tests__/OrchestratorApi_general.spec.ts
+++ b/__tests__/OrchestratorApi_general.spec.ts
@@ -22,4 +22,12 @@ describe('OrchestratorApi_general', () => {
       }
     })
   })
+
+  it('汎用メソッド のテスト', async () => {
+    const isOData = false
+    const instances = await api.getArray('/api/Stats/GetLicenseStats',
+      { 'tenantId': 1, days: 100 }, isOData)
+    console.table(instances)
+  })
+
 })

--- a/__tests__/OrchestratorApi_queue.spec.ts
+++ b/__tests__/OrchestratorApi_queue.spec.ts
@@ -4,13 +4,18 @@ import config from 'config'
 
 describe('OrchestratorApi_queue', () => {
 
-  const api = new OrchestratorApi(config)
+  const userConfig = (config as any).OrchestratorApi_queue.userApi
+  const robotConfig = (config as any).OrchestratorApi_queue.robotApi
+
+  const api = new OrchestratorApi(userConfig)
+  const robotApi = new OrchestratorApi(robotConfig)
 
   beforeEach(async () => {
     await api.authenticate()
+    await robotApi.authenticate()
   })
 
-  describe('OrchestratorApi のテスト', () => {
+  describe('Queue作成、Queue投入テスト', () => {
 
     const testQueueDef = {
       Name: 'testQueue' + Math.floor(Math.random() * 1000),
@@ -102,17 +107,13 @@ describe('OrchestratorApi_queue', () => {
     })
 
     afterEach(async () => {
-      const queueDefs: any[] = await api.queueDefinition.findByName(testQueueDef.Name)
-      // console.table(queueDefs)
-      for (const queueDef of queueDefs) {
-        await api.queueDefinition.delete(queueDef.Id)
-      }
+      const queueDef = await api.queueDefinition.findByName(testQueueDef.Name)
+      await api.queueDefinition.delete(queueDef.Id)
     })
 
   })
 
-
-  describe('OrchestratorApi のテスト1', () => {
+  describe('QueueDefinitionのテスト1', () => {
     describe('QueueDefを作成する。期待値と比較するテスト。', () => {
 
       const expected = {
@@ -123,10 +124,9 @@ describe('OrchestratorApi_queue', () => {
         EnforceUniqueReference: true, // 一意の参照(一意のRefをつけるかどうか)
       }
 
-      it('Queue登録テスト', async () => {
+      it('QueueDefテスト', async () => {
         let Id: number = 0
         try {
-          // Queueへデータ投入
           const result = await api.queueDefinition.create(expected)
           Id = result.Id
           expect(result).toEqual({
@@ -146,12 +146,6 @@ describe('OrchestratorApi_queue', () => {
             'SlaInMinutes': expect.anything(),
             'SpecificDataJsonSchema': null
           })
-
-          // // date で投げたデータは文字列で返ってくるので、再度オブジェクトにして比較。
-          // expect(typeof result.SpecificContent.MailDate).toBe('string')
-          // // expect(result.SpecificContent.MailDate).toBeInstanceOf(String) // なんかうまくいかない
-          // expect(new Date(result.SpecificContent.MailDate)).toMatchObject(expected.MailDate)
-
           // 検索して、見つかること。
           const findResult = await api.queueDefinition.find(Id)
           expect(findResult.Id).toBe(Id)
@@ -167,5 +161,129 @@ describe('OrchestratorApi_queue', () => {
       afterEach(async () => { })
     })
 
+  })
+
+  const createQueueItem = (queueName: string) => {
+    const SpecificContent = {
+      MessageId: '<7A6877E2452943F59DEE8AD81FB403A9@12345>',
+      MailDateStr: 'Sat, 7 Dec 2019 02:00:05 +0900',
+      Subject: 'テストメール',
+      MailDate: new Date('2019-12-07T02:00:05+09:00'),
+      Body: 'テストメール。添付の通りです。\r\n',
+      attachmentFileName: 'report_20191206.html',
+      'MessageId@odata.type': '#String',
+      'MailDateStr@odata.type': '#String',
+      'Subject@odata.type': '#String',
+      'Body@odata.type': '#String',
+      'attachmentFileName@odata.type': '#String',
+    }
+    const newQueue = {
+      itemData: {
+        Priority: 'Normal',
+        Name: queueName,
+        SpecificContent: SpecificContent,
+        // Reference: SpecificContent.MessageId,
+        Reference: (Math.floor(Math.random() * 10000)).toString(),
+      },
+    }
+    return newQueue
+  }
+
+  describe('Transactionのテスト', () => {
+    const testQueueDef = {
+      Name: 'testQueue' + Math.floor(Math.random() * 1000),
+      Description: 'Queue for UnitTest',
+      AcceptAutomaticallyRetry: true, // 自動リトライ
+      MaxNumberOfRetries: 3, // 最大リトライ数
+      EnforceUniqueReference: true, // 一意の参照(一意のRefをつけるかどうか)
+    }
+
+    beforeEach(async () => {
+      const result = await api.queueDefinition.create(testQueueDef)
+    })
+
+    describe('Transactionの成功と失敗のテスト。', () => {
+      it('tranTest', async () => {
+        const newQueue1 = createQueueItem(testQueueDef.Name)
+        const newQueue2 = createQueueItem(testQueueDef.Name)
+        try {
+          const result1 = await api.queueItem.create(newQueue1)
+          const result2 = await api.queueItem.create(newQueue2)
+          {// 1個目成功
+            const queueItem = await robotApi.queueOperation.getQueueAndStartTransaction(testQueueDef.Name)
+            const queueItemId: number = queueItem.Id
+
+            expect(queueItem.Reference).toBe(result1.Reference)
+            const status = {
+              'transactionResult': {
+                'IsSuccessful': true,
+                'Output': {}
+              }
+            }
+            await robotApi.queueOperation.setTransactionResult(queueItemId, status)
+          }
+
+          let systemFailRef: string = ''
+          { // 2個目失敗、システム例外なので、再ラン
+            const queueItem = await robotApi.queueOperation.getQueueAndStartTransaction(testQueueDef.Name)
+            const queueItemId: number = queueItem.Id
+            systemFailRef = queueItem.Reference
+
+            expect(queueItem.Reference).toBe(result2.Reference)
+            const status = {
+              'transactionResult': {
+                'IsSuccessful': false,
+                'ProcessingException': {
+                  'Reason': 'testError',
+                  'Type': 'ApplicationException'
+                },
+                'Output': {}
+              }
+            }
+            await robotApi.queueOperation.setTransactionResult(queueItemId, status)
+          }
+          { // システム例外後の再度のStartTransactionなので、先ほどと同じやつのリトライが取れるはず
+            const queueItem = await robotApi.queueOperation.getQueueAndStartTransaction(testQueueDef.Name)
+            const queueItemId: number = queueItem.Id
+
+            expect(queueItem.Reference).toBe(systemFailRef) // 先ほどのRefと同じはず
+            const status = {
+              'transactionResult': {
+                'IsSuccessful': false,
+                'ProcessingException': {
+                  'Reason': 'testError',
+                  'Type': 'BusinessException'
+                },
+                'Output': {}
+              }
+            }
+            await robotApi.queueOperation.setTransactionResult(queueItemId, status)
+            // ビジネス例外をスローしたので、再ランはやめて失敗となるはず。
+          }
+
+          // 検索して、見つかること。
+          const def = await api.queueDefinition.findByName(testQueueDef.Name)
+          const queueItems = await api.queueItem.findAll({
+            $filter: `QueueDefinitionId eq ${def.Id}`,
+          })
+          expect(queueItems.length).toBe(3)
+
+          const findResult1 = await api.queueItem.find(result1.Id)
+          expect(findResult1.Id).toBe(result1.Id)
+
+          const findResult2 = await api.queueItem.find(result2.Id)
+          expect(findResult2.Id).toBe(result2.Id)
+
+        } catch (error) {
+          fail(error)
+        } finally {
+        }
+      })
+    })
+
+    afterEach(async () => {
+      const queueDef = await api.queueDefinition.findByName(testQueueDef.Name)
+      // await api.queueDefinition.delete(queueDef.Id)
+    })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -465,8 +465,8 @@ class OrchestratorApi implements IOrchestratorApi {
   // フォルダー(OU)
   // Webhook
 
-  getArray = (apiPath: string, queries?: any): Promise<Array<any>> => {
-    return getArray(this.config, this.accessToken, apiPath, queries)
+  getArray = (apiPath: string, queries?: any, isOdata: boolean = true): Promise<Array<any>> => {
+    return getArray(this.config, this.accessToken, apiPath, queries, isOdata)
   }
 
   getData = (apiPath: string): Promise<any> => {


### PR DESCRIPTION
Transaction系のメソッドに対応。

Robotモードで、TransactionからQueueItemを取得し、処理後にTransactionのステータスを変更するコトを可能にした。そのテストケースの追加。

また、RobotモードやUserモードの両方の設定が必要になったので、local.jsonに複数の設定を書いてある前提とした

QueueDefinitionについて、名前指定の場合は1件に定まるので、配列でなくそのままオブジェクトを返すことにした。
-  findByName(name: String): Promise<Array<any>> {
+  findByName(name: String): Promise<any> {


/api/Stats/GetLicenseStats などはOData形式でなくそのまま配列で返ってきたりするので、処理の仕方が異なる。そのための判定フラグを追加。
